### PR TITLE
Use css to calculate font sizes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*.html]
+indent_style = tab

--- a/d3-progress-meter.html
+++ b/d3-progress-meter.html
@@ -16,7 +16,15 @@ Custom property | Description | Default
 `--progress-meter-color-low` | Color of the progress bar for low values | `#f44336`
 `--progress-meter-color-medium` | Color of the progress bar for medium values | `#ffeb3b`
 `--progress-meter-color-high` | Color of the progress bar for high values | `#4caf50`
+`--progress-meter-current-font-size-scale` | Controls font size of `current-text` | `0.5`
+`--progress-meter-goal-font-size-scale` | Controls font size of `goal-text` | `0.2`
+`--progress-meter-type-font-size-scale` | Controls font size of `type-text` | `0.25`
+`--progress-meter-type-width-scale` | Controls width of `type-text` | `4`
+`--progress-meter-caption-font-size-scale` | Controls font size of `caption` | `0.2`
+`--progress-meter-caption-width-scale` | Controls width of `caption` | `2`
 
+All the `-scale` properties are used to set the sizes proportionally to the element's `radius`. For example, by default
+the `current-text` font size is half that of the `radius`.
 
 ### Example
 
@@ -33,12 +41,12 @@ Custom property | Description | Default
 		<style>
 			:host {
 				display: inline-block;
-				--progess-meter-current-font-size-divisor: 2;
-				--progess-meter-goal-font-size-divisor: 5;
-				--progess-meter-type-font-size-divisor: 4;
-				--progess-meter-type-width-multiplier: 4;
-				--progess-meter-caption-font-size-divisor: 5;
-				--progess-meter-caption-width-multiplier: 2;
+				--progress-meter-current-font-size-scale: 0.5;
+				--progress-meter-goal-font-size-scale: 0.2;
+				--progress-meter-type-font-size-scale: 0.25;
+				--progress-meter-type-width-scale: 4;
+				--progress-meter-caption-font-size-scale: 0.2;
+				--progress-meter-caption-width-scale: 2;
 			}
 			#background {
 				/* var(--paper-grey-300) */
@@ -60,19 +68,19 @@ Custom property | Description | Default
 				font-family: Arial, sans-serif;
 			}
 			#type {
-				font-size: calc(var(--radius) / var(--progess-meter-type-font-size-divisor));
-				width: calc(var(--radius) * var(--progess-meter-type-width-multiplier));
+				font-size: calc(var(--radius) * var(--progress-meter-type-font-size-scale));
+				width: calc(var(--radius) * var(--progress-meter-type-width-scale));
 			}
 			#caption {
-				font-size: calc(var(--radius) / var(--progess-meter-caption-font-size-divisor));
-				width: calc(var(--radius) * var(--progess-meter-caption-width-multiplier));
+				font-size: calc(var(--radius) * var(--progress-meter-caption-font-size-scale));
+				width: calc(var(--radius) * var(--progress-meter-caption-width-scale));
 			}
 			#goal {
-				font-size: calc(var(--radius) / var(--progess-meter-goal-font-size-divisor));
+				font-size: calc(var(--radius) * var(--progress-meter-goal-font-size-scale));
 			}
 			#current {
 				font-weight: bold;
-				font-size: calc(var(--radius) / var(--progess-meter-current-font-size-divisor));
+				font-size: calc(var(--radius) * var(--progress-meter-current-font-size-scale));
 			}
 			#type {
 				margin-top: 5px;

--- a/d3-progress-meter.html
+++ b/d3-progress-meter.html
@@ -218,7 +218,7 @@ the `current-text` font size is half that of the `radius`.
 				this.updateStyles();
 			} else {
 				// Polymer 2.0+
-				// 			  this.updateStyles({'--radius': this.radius + 'px'});
+				this.updateStyles({'--radius': this.radius + 'px'});
 			}
 
 			this.$.background.setAttribute('d', this.backgroundArc.endAngle(2 * Math.PI)());

--- a/d3-progress-meter.html
+++ b/d3-progress-meter.html
@@ -204,13 +204,13 @@ Custom property | Description | Default
 						.innerRadius(0.825 * this.radius)
 						.outerRadius(0.85 * this.radius);
 
-			if(this.customStyle) {
-			  // Polymer 1.x
-			  this.customStyle['--radius'] = this.radius + 'px';
-			  this.updateStyles();
+			if (this.customStyle) {
+				// Polymer 1.x
+				this.customStyle['--radius'] = this.radius + 'px';
+				this.updateStyles();
 			} else {
-			  // Polymer 2.0+
-			  this.updateStyles({'--radius': this.radius + 'px'});
+				// Polymer 2.0+
+				// 			  this.updateStyles({'--radius': this.radius + 'px'});
 			}
 
 			this.$.background.setAttribute('d', this.backgroundArc.endAngle(2 * Math.PI)());

--- a/d3-progress-meter.html
+++ b/d3-progress-meter.html
@@ -33,6 +33,12 @@ Custom property | Description | Default
 		<style>
 			:host {
 				display: inline-block;
+				--progess-meter-current-font-size-divisor: 2;
+				--progess-meter-goal-font-size-divisor: 5;
+				--progess-meter-type-font-size-divisor: 4;
+				--progess-meter-type-width-multiplier: 4;
+				--progess-meter-caption-font-size-divisor: 5;
+				--progess-meter-caption-width-multiplier: 2;
 			}
 			#background {
 				/* var(--paper-grey-300) */
@@ -53,8 +59,20 @@ Custom property | Description | Default
 			#current,#goal,#type,#caption {
 				font-family: Arial, sans-serif;
 			}
+			#type {
+				font-size: calc(var(--radius) / var(--progess-meter-type-font-size-divisor));
+				width: calc(var(--radius) * var(--progess-meter-type-width-multiplier));
+			}
+			#caption {
+				font-size: calc(var(--radius) / var(--progess-meter-caption-font-size-divisor));
+				width: calc(var(--radius) * var(--progess-meter-caption-width-multiplier));
+			}
+			#goal {
+				font-size: calc(var(--radius) / var(--progess-meter-goal-font-size-divisor));
+			}
 			#current {
 				font-weight: bold;
+				font-size: calc(var(--radius) / var(--progess-meter-current-font-size-divisor));
 			}
 			#type {
 				margin-top: 5px;
@@ -186,12 +204,15 @@ Custom property | Description | Default
 						.innerRadius(0.825 * this.radius)
 						.outerRadius(0.85 * this.radius);
 
-			this.$.current.style.fontSize = this.radius/2 + 'px';
-			this.$.goal.style.fontSize = this.radius/5 + 'px';
-			this.$.type.style.fontSize = this.radius/4 + 'px';
-			this.$.type.style.width = 2 * this.radius + 'px';
-			this.$.caption.style.fontSize = this.radius/5 + 'px';
-			this.$.caption.style.width = 2 * this.radius + 'px';
+			if(this.customStyle) {
+			  // Polymer 1.x
+			  this.customStyle['--radius'] = this.radius + 'px';
+			  this.updateStyles();
+			} else {
+			  // Polymer 2.0+
+			  this.updateStyles({'--radius': this.radius + 'px'});
+			}
+
 			this.$.background.setAttribute('d', this.backgroundArc.endAngle(2 * Math.PI)());
 		},
 		_onPercentageChanged: function() {

--- a/test/d3-progress-meter.html
+++ b/test/d3-progress-meter.html
@@ -50,16 +50,19 @@
 						expect(svg.getAttribute("height")).to.be.eql("200");
 					});
 
-					test('sets font-sizes based on radius attribute', function() {
+					test('sets font-sizes based on radius attribute', function(done) {
 						var current = Polymer.dom(meter.root).querySelector("#current");
 						var goal = Polymer.dom(meter.root).querySelector("#goal");
 						var type = Polymer.dom(meter.root).querySelector("#type");
 						var caption = Polymer.dom(meter.root).querySelector("#caption");
 
+						flush(function() {
 						expect(current.style.fontSize).to.be.eql("50px");
 						expect(goal.style.fontSize).to.be.eql("20px");
 						expect(type.style.fontSize).to.be.eql("25px");
 						expect(caption.style.fontSize).to.be.eql("20px");
+						done();
+                        });
 					});
 				});
 

--- a/test/d3-progress-meter.html
+++ b/test/d3-progress-meter.html
@@ -50,19 +50,16 @@
 						expect(svg.getAttribute("height")).to.be.eql("200");
 					});
 
-					test('sets font-sizes based on radius attribute', function(done) {
+					test('sets font-sizes based on radius attribute', function() {
 						var current = Polymer.dom(meter.root).querySelector("#current");
 						var goal = Polymer.dom(meter.root).querySelector("#goal");
 						var type = Polymer.dom(meter.root).querySelector("#type");
 						var caption = Polymer.dom(meter.root).querySelector("#caption");
 
-						flush(function() {
-						expect(current.style.fontSize).to.be.eql("50px");
-						expect(goal.style.fontSize).to.be.eql("20px");
-						expect(type.style.fontSize).to.be.eql("25px");
-						expect(caption.style.fontSize).to.be.eql("20px");
-						done();
-                        });
+						expect(getComputedStyle(current).fontSize).to.be.eql("50px");
+						expect(getComputedStyle(goal).fontSize).to.be.eql("20px");
+						expect(getComputedStyle(type).fontSize).to.be.eql("25px");
+						expect(getComputedStyle(caption).fontSize).to.be.eql("20px");
 					});
 				});
 

--- a/test/d3-progress-meter.html
+++ b/test/d3-progress-meter.html
@@ -105,7 +105,7 @@
 
 					test('sets progress diameter based on percentage attribute', function(done) {
 						// Wait until animation finishes
-			            setTimeout(function() {
+						setTimeout(function() {
 							var progress = Polymer.dom(meter.root).querySelector("#progress");
 							expect(progress.getAttribute("d")).to.be.eql("M6.123233995736766e-15,-100A100,100 0 0,1 30.901699437494745,-95.10565162951535L27.81152949374527,-85.59508646656381A90,90 0 0,0 5.5109105961630896e-15,-90Z");
 							done();


### PR DESCRIPTION
Fixes #1 by replacing setting font styles directly with CSS' `calc()`.

I don't particularly like the `-divisor` and `-multiplier` suffixes. How about I change all of those to multiplication and call the properties `-scale`.

* [x] Updated readme/docs